### PR TITLE
fix: threejs require BufferGeometry postion attr to be 3d

### DIFF
--- a/src/LabelPool.ts
+++ b/src/LabelPool.ts
@@ -338,15 +338,15 @@ export class LabelPool extends EventDispatcher<{ type: "scaleFactorChange" | "at
   private availableLabels: Label[] = [];
   private disposed = false;
 
-  static QUAD_POINTS: [number, number][] = [
-    [0, 0],
-    [0, 1],
-    [1, 0],
-    [1, 0],
-    [0, 1],
-    [1, 1],
+  static QUAD_POINTS: [number, number, number][] = [
+    [0, 0, 0],
+    [0, 1, 0],
+    [1, 0, 0],
+    [1, 0, 0],
+    [0, 1, 0],
+    [1, 1, 0],
   ];
-  static QUAD_POSITIONS = new THREE.BufferAttribute(new Float32Array(this.QUAD_POINTS.flat()), 2);
+  static QUAD_POSITIONS = new THREE.BufferAttribute(new Float32Array(this.QUAD_POINTS.flat()), 3);
   static QUAD_UVS = new THREE.BufferAttribute(
     new Float32Array(this.QUAD_POINTS.flatMap(([x, y]) => [x, 1 - y])),
     2,

--- a/src/LabelPool.ts
+++ b/src/LabelPool.ts
@@ -25,7 +25,7 @@ uniform vec2 uAnchorPoint;
 uniform vec2 uCanvasSize;
 
 in vec2 uv;
-in vec2 position;
+in vec3 position;
 in vec2 instanceBoxPosition, instanceCharPosition;
 in vec2 instanceUv;
 in vec2 instanceBoxSize, instanceCharSize;
@@ -37,8 +37,8 @@ void main() {
   vec2 boxUv = (uv * instanceBoxSize - (instanceCharPosition - instanceBoxPosition)) / instanceCharSize;
   vInsideChar = boxUv;
   vUv = (instanceUv + boxUv * instanceCharSize) / uTextureSize;
-  vec2 vertexPos = (instanceBoxPosition + position * instanceBoxSize - uAnchorPoint * uLabelSize) * uScale;
-  vPosInLabel = (instanceBoxPosition + position * instanceBoxSize);
+  vec2 vertexPos = (instanceBoxPosition + position.xy * instanceBoxSize - uAnchorPoint * uLabelSize) * uScale;
+  vPosInLabel = (instanceBoxPosition + position.xy * instanceBoxSize);
 
   // Adapted from THREE.ShaderLib.sprite
   if (uBillboard) {


### PR DESCRIPTION
### Public-Facing Changes

None

### Description

With threejs updates on WebGLRenderer https://github.com/mrdoob/three.js/pull/25913,
it will call `geometry.computeBoundingSphere();`, which will lead to Error: position has NaN value.

In fact, threejs require BufferGeometry's position attribute to be 3d.


