### PR TITLE
Move Chromatic projectToken to ci.yml to allow PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,6 @@ jobs:
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          projectToken: de34ab810be0
           autoAcceptChanges: main
           exitOnceUploaded: true


### PR DESCRIPTION
Unblocks #170 