### PR TITLE
Support foreground and background opacities

### DIFF
--- a/src/LabelPool.stories.tsx
+++ b/src/LabelPool.stories.tsx
@@ -13,7 +13,8 @@ const meta: Meta<typeof BasicTemplate> = {
     cameraMode: { control: "inline-radio", options: ["perspective", "orthographic"] },
     lineHeight: { control: { type: "range", min: 0.5, max: 20, step: 0.01 } },
     scaleFactor: { control: { type: "range", min: 0, max: 2, step: 0.01 } },
-    opacity: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
+    bgOpacity: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
+    fgOpacity: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
     anchorPointX: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
     anchorPointY: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
     positionX: { control: { type: "range", min: -5, max: 5, step: 0.01 } },
@@ -26,7 +27,8 @@ const meta: Meta<typeof BasicTemplate> = {
     scaleFactor: 1,
     foregroundColor: "#000000",
     backgroundColor: "#ffffff",
-    opacity: 1,
+    fgOpacity: 1,
+    bgOpacity: 1,
     cameraMode: "perspective",
     billboard: false,
     sizeAttenuation: true,
@@ -98,7 +100,8 @@ function BasicTemplate({
   scaleFactor,
   foregroundColor,
   backgroundColor,
-  opacity,
+  fgOpacity,
+  bgOpacity,
   billboard,
   sizeAttenuation,
   cameraMode = "perspective",
@@ -113,7 +116,8 @@ function BasicTemplate({
   scaleFactor: number;
   foregroundColor: string;
   backgroundColor: string;
-  opacity: number;
+  fgOpacity: number;
+  bgOpacity: number;
   cameraMode: "perspective" | "orthographic";
   billboard: boolean;
   sizeAttenuation: boolean;
@@ -137,6 +141,12 @@ function BasicTemplate({
     setLabel(newLabel);
 
     storyScene.scene.add(newLabel);
+    const defaultLabel = storyScene.labelPool.acquire();
+    // test transparency
+    defaultLabel.setText("Default");
+    defaultLabel.position.set(0, 0, -1);
+    storyScene.scene.add(defaultLabel);
+
     storyScene.render();
 
     return () => {
@@ -171,13 +181,6 @@ function BasicTemplate({
 
   useEffect(() => {
     if (label) {
-      label.setOpacity(opacity);
-      storyScene.render();
-    }
-  }, [opacity, label, storyScene]);
-
-  useEffect(() => {
-    if (label) {
       label.setBillboard(billboard);
       storyScene.render();
     }
@@ -200,18 +203,18 @@ function BasicTemplate({
   useEffect(() => {
     if (label) {
       const color = new THREE.Color(foregroundColor);
-      label.setColor(color.r, color.g, color.b);
+      label.setColor(color.r, color.g, color.b, fgOpacity);
       storyScene.render();
     }
-  }, [label, foregroundColor, storyScene]);
+  }, [label, foregroundColor, storyScene, fgOpacity]);
 
   useEffect(() => {
     if (label) {
       const color = new THREE.Color(backgroundColor);
-      label.setBackgroundColor(color.r, color.g, color.b);
+      label.setBackgroundColor(color.r, color.g, color.b, bgOpacity);
       storyScene.render();
     }
-  }, [label, backgroundColor, storyScene]);
+  }, [label, backgroundColor, storyScene, bgOpacity]);
 
   useEffect(() => {
     if (label) {

--- a/src/LabelPool.stories.tsx
+++ b/src/LabelPool.stories.tsx
@@ -234,7 +234,7 @@ export const CustomColors: StoryObj<typeof meta> = {
   args: {
     foregroundColor: "#ff9d42",
     backgroundColor: "#1295d1",
-    bgOpacity: 0.5,
-    fgOpacity: 0.2,
+    bgOpacity: 0.8,
+    fgOpacity: 0.3,
   },
 };

--- a/src/LabelPool.stories.tsx
+++ b/src/LabelPool.stories.tsx
@@ -52,10 +52,18 @@ class StoryScene {
 
   perspective = true;
 
+  bgCube?: THREE.Mesh;
+
   constructor() {
     this.perspectiveCamera.position.set(4, 4, 4);
     this.scene.background = new THREE.Color(0xf0f0f0);
     this.scene.add(new THREE.AxesHelper(5));
+    // show transparency in snapshot tests
+    const cubeGeometry = new THREE.BoxGeometry(0.2, 0.2, 2);
+    const cubeMaterial = new THREE.MeshNormalMaterial();
+    this.bgCube = new THREE.Mesh(cubeGeometry, cubeMaterial);
+    this.bgCube.position.set(0, 0, -0.8);
+    this.scene.add(this.bgCube);
   }
 
   dispose() {
@@ -141,11 +149,6 @@ function BasicTemplate({
     setLabel(newLabel);
 
     storyScene.scene.add(newLabel);
-    const defaultLabel = storyScene.labelPool.acquire();
-    // test transparency
-    defaultLabel.setText("Default");
-    defaultLabel.position.set(0, 0, -1);
-    storyScene.scene.add(defaultLabel);
 
     storyScene.render();
 
@@ -231,5 +234,7 @@ export const CustomColors: StoryObj<typeof meta> = {
   args: {
     foregroundColor: "#ff9d42",
     backgroundColor: "#1295d1",
+    bgOpacity: 0.5,
+    fgOpacity: 0.2,
   },
 };

--- a/src/LabelPool.ts
+++ b/src/LabelPool.ts
@@ -103,11 +103,11 @@ float aastep(float threshold, float value) {
 
 void main() {
   float dist = texture(uMap, vUv).a;
-  vec4 color = vec4(uBackgroundColor * (1.0 - dist) + uColor * dist);
-  outColor = vec4(mix(uBackgroundColor, uColor, aastep(0.75, dist)));
+  vec4 color = uBackgroundColor * (1.0 - dist) + uColor * dist;
+  outColor = mix(uBackgroundColor, uColor, aastep(0.75, dist));
 
   bool insideChar = vInsideChar.x >= 0.0 && vInsideChar.x <= 1.0 && vInsideChar.y >= 0.0 && vInsideChar.y <= 1.0;
-  outColor = insideChar ? outColor : vec4(uBackgroundColor);
+  outColor = insideChar ? outColor : uBackgroundColor;
   outColor = LinearTosRGB(outColor); // assumes output encoding is srgb
 }
 `,
@@ -278,25 +278,21 @@ export class Label extends THREE.Object3D {
   }
 
   /** Values should be in working (linear-srgb) color space */
-  setColor(r: number, g: number, b: number, a?: number): void {
+  setColor(r: number, g: number, b: number, a = 1): void {
     this.material.uniforms.uColor!.value[0] = r;
     this.material.uniforms.uColor!.value[1] = g;
     this.material.uniforms.uColor!.value[2] = b;
-    if (a != undefined) {
-      this.material.uniforms.uColor!.value[3] = a;
-      this.#updateTransparency();
-    }
+    this.material.uniforms.uColor!.value[3] = a;
+    this.#updateTransparency();
   }
 
   /** Values should be in working (linear-srgb) color space */
-  setBackgroundColor(r: number, g: number, b: number, a?: number): void {
+  setBackgroundColor(r: number, g: number, b: number, a = 1): void {
     this.material.uniforms.uBackgroundColor!.value[0] = r;
     this.material.uniforms.uBackgroundColor!.value[1] = g;
     this.material.uniforms.uBackgroundColor!.value[2] = b;
-    if (a != undefined) {
-      this.material.uniforms.uBackgroundColor!.value[3] = a;
-      this.#updateTransparency();
-    }
+    this.material.uniforms.uBackgroundColor!.value[3] = a;
+    this.#updateTransparency();
   }
 
   #updateTransparency(): void {

--- a/src/LabelPool.ts
+++ b/src/LabelPool.ts
@@ -85,8 +85,7 @@ void main() {
   precision mediump float;
 #endif
 uniform sampler2D uMap;
-uniform float uOpacity;
-uniform mediump vec3 uColor, uBackgroundColor;
+uniform mediump vec4 uColor, uBackgroundColor;
 uniform float uScale;
 uniform vec2 uLabelSize;
 in mediump vec2 vUv;
@@ -104,11 +103,11 @@ float aastep(float threshold, float value) {
 
 void main() {
   float dist = texture(uMap, vUv).a;
-  vec4 color = vec4(uBackgroundColor.rgb * (1.0 - dist) + uColor * dist, uOpacity);
-  outColor = vec4(mix(uBackgroundColor, uColor, aastep(0.75, dist)), uOpacity);
+  vec4 color = vec4(uBackgroundColor * (1.0 - dist) + uColor * dist);
+  outColor = vec4(mix(uBackgroundColor, uColor, aastep(0.75, dist)));
 
   bool insideChar = vInsideChar.x >= 0.0 && vInsideChar.x <= 1.0 && vInsideChar.y >= 0.0 && vInsideChar.y <= 1.0;
-  outColor = insideChar ? outColor : vec4(uBackgroundColor, uOpacity);
+  outColor = insideChar ? outColor : vec4(uBackgroundColor);
   outColor = LinearTosRGB(outColor); // assumes output encoding is srgb
 }
 `,
@@ -124,9 +123,8 @@ void main() {
           value: [params.atlasTexture?.image.width ?? 0, params.atlasTexture?.image.height ?? 0],
         },
         uMap: { value: params.atlasTexture },
-        uOpacity: { value: 1 },
-        uColor: { value: [0, 0, 0] },
-        uBackgroundColor: { value: [1, 1, 1] },
+        uColor: { value: [0, 0, 0, 1] },
+        uBackgroundColor: { value: [1, 1, 1, 1] },
       },
 
       side: THREE.DoubleSide,
@@ -192,7 +190,6 @@ export class Label extends THREE.Object3D {
     };
 
     this.add(this.mesh);
-    this.setOpacity(1);
 
     labelPool.addEventListener("scaleFactorChange", () => {
       // Trigger recalculation of scale uniform
@@ -281,22 +278,31 @@ export class Label extends THREE.Object3D {
   }
 
   /** Values should be in working (linear-srgb) color space */
-  setColor(r: number, g: number, b: number): void {
+  setColor(r: number, g: number, b: number, a?: number): void {
     this.material.uniforms.uColor!.value[0] = r;
     this.material.uniforms.uColor!.value[1] = g;
     this.material.uniforms.uColor!.value[2] = b;
+    if (a != undefined) {
+      this.material.uniforms.uColor!.value[3] = a;
+      this.#updateTransparency();
+    }
   }
 
   /** Values should be in working (linear-srgb) color space */
-  setBackgroundColor(r: number, g: number, b: number): void {
+  setBackgroundColor(r: number, g: number, b: number, a?: number): void {
     this.material.uniforms.uBackgroundColor!.value[0] = r;
     this.material.uniforms.uBackgroundColor!.value[1] = g;
     this.material.uniforms.uBackgroundColor!.value[2] = b;
+    if (a != undefined) {
+      this.material.uniforms.uBackgroundColor!.value[3] = a;
+      this.#updateTransparency();
+    }
   }
 
-  setOpacity(opacity: number): void {
-    this.material.uniforms.uOpacity!.value = opacity;
-    const transparent = opacity < 1;
+  #updateTransparency(): void {
+    const bgOpacity = this.material.uniforms.uBackgroundColor!.value[3];
+    const fgOpacity = this.material.uniforms.uColor!.value[3];
+    const transparent = bgOpacity < 1 || fgOpacity < 1;
     this.material.transparent = transparent;
     this.material.depthWrite = !transparent;
   }


### PR DESCRIPTION
`setColor` and `setBackgroundColor` now take an optional 4th argument for an alpha value.

Also removes `setOpacity`.


FG-5007