### PR TITLE
Enable logarithmic depth buffer

### DIFF
--- a/src/LabelPool.ts
+++ b/src/LabelPool.ts
@@ -13,7 +13,9 @@ export class LabelMaterial extends THREE.RawShaderMaterial {
       glslVersion: THREE.GLSL3,
       vertexShader: /* glsl */ `\
 #include <common>
-#include <logdepthbuf_pars_vertex>
+
+uniform bool uLogDepth;
+uniform float logDepthBufFC;
 
 precision highp float;
 precision highp int;
@@ -65,14 +67,15 @@ void main() {
   } else {
     gl_Position = projectionMatrix * modelViewMatrix * vec4(vertexPos, 0.0, 1.0);
   }
-  #include <logdepthbuf_vertex>
+  if (uLogDepth && isPerspectiveMatrix( projectionMatrix ) ) {
+    gl_Position.z = log2( max( EPSILON, gl_Position.w + 1.0 ) ) * logDepthBufFC - 1.0;
+    gl_Position.z *= gl_Position.w;
+  }
 }
 `,
       fragmentShader:
         params.picking === true
           ? /* glsl */ `\
-#include <logdepthbuf_pars_fragment>
-
 #ifdef GL_FRAGMENT_PRECISION_HIGH
   precision highp float;
 #else
@@ -82,11 +85,9 @@ uniform vec4 objectId;
 out vec4 outColor;
 void main() {
   outColor = objectId;
-  #include <logdepthbuf_fragment>
 }
 `
           : /* glsl */ `\
-#include <logdepthbuf_pars_fragment>
 #ifdef GL_FRAGMENT_PRECISION_HIGH
   precision highp float;
 #else
@@ -122,13 +123,13 @@ void main() {
   bool insideChar = vInsideChar.x >= 0.0 && vInsideChar.x <= 1.0 && vInsideChar.y >= 0.0 && vInsideChar.y <= 1.0;
   outColor = insideChar ? outColor : uBackgroundColor;
   outColor = LinearTosRGB(outColor); // assumes output encoding is srgb
-  #include <logdepthbuf_fragment>
 }
 `,
       uniforms: {
         objectId: { value: [NaN, NaN, NaN, NaN] },
         uAnchorPoint: { value: [0.5, 0.5] },
         uBillboard: { value: false },
+        uLogDepth: { value: false },
         uSizeAttenuation: { value: true },
         uLabelSize: { value: [0, 0] },
         uCanvasSize: { value: [0, 0] },
@@ -140,21 +141,12 @@ void main() {
         uColor: { value: [0, 0, 0, 1] },
         uBackgroundColor: { value: [1, 1, 1, 1] },
       },
-
       side: THREE.DoubleSide,
       transparent: false,
       depthWrite: true,
     });
 
     this.picking = params.picking ?? false;
-
-    this.onBeforeCompile = (_, renderer) => {
-      if (renderer.capabilities.logarithmicDepthBuffer) {
-        this.material.defines = { USE_LOGDEPTHBUF: "" };
-      } else {
-        this.material.defines = {};
-      }
-    };
   }
 }
 
@@ -225,6 +217,9 @@ export class Label extends THREE.Object3D {
       this.material.uniforms.uCanvasSize!.value[1] = tempVec2.y;
       this.pickingMaterial.uniforms.uCanvasSize!.value[0] = tempVec2.x;
       this.pickingMaterial.uniforms.uCanvasSize!.value[1] = tempVec2.y;
+
+      this.material.uniforms.uLogDepth!.value = renderer.capabilities.logarithmicDepthBuffer;
+      this.pickingMaterial.uniforms.uLogDepth!.value = renderer.capabilities.logarithmicDepthBuffer;
     };
 
     this.add(this.mesh);

--- a/src/LabelPool.ts
+++ b/src/LabelPool.ts
@@ -8,7 +8,11 @@ const tempVec2 = new THREE.Vector2();
 export class LabelMaterial extends THREE.RawShaderMaterial {
   picking: boolean;
 
-  constructor(params: { atlasTexture?: THREE.Texture; picking?: boolean; logarithmicDepthBuffer?: boolean }) {
+  constructor(params: {
+    atlasTexture?: THREE.Texture;
+    picking?: boolean;
+    logarithmicDepthBuffer?: boolean;
+  }) {
     super({
       glslVersion: THREE.GLSL3,
       vertexShader: /* glsl */ `\
@@ -140,7 +144,7 @@ void main() {
         uColor: { value: [0, 0, 0, 1] },
         uBackgroundColor: { value: [1, 1, 1, 1] },
       },
-      defines: (params.logarithmicDepthBuffer ?? false) ?  {USE_LOGDEPTHBUF: "" } : {},
+      defines: params.logarithmicDepthBuffer ?? false ? { USE_LOGDEPTHBUF: "" } : {},
       side: THREE.DoubleSide,
       transparent: false,
       depthWrite: true,
@@ -205,10 +209,14 @@ export class Label extends THREE.Object3D {
     this.geometry.setAttribute("instanceBoxSize", this.instanceBoxSize);
     this.geometry.setAttribute("instanceCharSize", this.instanceCharSize);
 
-    this.material = new LabelMaterial({ atlasTexture: labelPool.atlasTexture,
-					logarithmicDepthBuffer: labelPool.logarithmicDepthBuffer});
-    this.pickingMaterial = new LabelMaterial({ picking: true,
-					       logarithmicDepthBuffer: labelPool.logarithmicDepthBuffer});
+    this.material = new LabelMaterial({
+      atlasTexture: labelPool.atlasTexture,
+      logarithmicDepthBuffer: labelPool.logarithmicDepthBuffer,
+    });
+    this.pickingMaterial = new LabelMaterial({
+      picking: true,
+      logarithmicDepthBuffer: labelPool.logarithmicDepthBuffer,
+    });
 
     this.mesh = new InstancedMeshWithBasicBoundingSphere(this.geometry, this.material, 0);
     this.mesh.userData.pickingMaterial = this.pickingMaterial;
@@ -391,7 +399,7 @@ export class LabelPool extends EventDispatcher<{ scaleFactorChange: object; atla
   fontManager: FontManager;
   scaleFactor = 1;
   logarithmicDepthBuffer = false;
-    
+
   setScaleFactor(scaleFactor: number): void {
     this.scaleFactor = scaleFactor;
     this.dispatchEvent({ type: "scaleFactorChange" });

--- a/src/LabelPool.ts
+++ b/src/LabelPool.ts
@@ -7,6 +7,7 @@ const tempVec2 = new THREE.Vector2();
 
 export class LabelMaterial extends THREE.RawShaderMaterial {
   picking: boolean;
+  logarithmicDepthBuffer: boolean;
 
   constructor(params: { atlasTexture?: THREE.Texture; picking?: boolean }) {
     super({
@@ -147,12 +148,19 @@ void main() {
     });
 
     this.picking = params.picking ?? false;
+    this.logarithmicDepthBuffer = false;
 
     this.onBeforeCompile = (_, renderer) => {
-      if (renderer.capabilities.logarithmicDepthBuffer) {
-        this.material.defines = { USE_LOGDEPTHBUF: "" };
-      } else {
-        this.material.defines = {};
+      const new_depth_buffer_val: boolean = renderer.capabilities.logarithmicDepthBuffer;
+      if (new_depth_buffer_val !== this.logarithmicDepthBuffer) {
+        this.logarithmicDepthBuffer = new_depth_buffer_val;
+        if (this.logarithmicDepthBuffer) {
+          this.defines = { USE_LOGDEPTHBUF: "" };
+        } else {
+          this.defines = {};
+        }
+        // Ensure that we acquire the right shader program before rendering.
+        this.needsUpdate = true;
       }
     };
   }


### PR DESCRIPTION
### Public-Facing Changes

No changes to public APIs. If the THREE.WebGLRenderer is constructed with `logarithmicDepthBuffer: true`, the label will no longer appear behind content it should be in front of. This should resolve https://github.com/foxglove/three-text/issues/63.

### Description

This PR uses ShaderChunk.logdepthbuf_pars_{vertex, fragment} and ShaderChunk.logdepthbuf_{vertex, fragment} in the shaders for `LabelMaterial`. The #define symbol USE_LOGDEPTHBUF to toggle the shader behavior statically. We catch updates from the renderer in the `onBeforeCompile()` callback and use this to update the defines of the LabelMaterial if needed. This was tested with [this branch](https://github.com/foxglove/studio/pull/7505/files) of foxglove studio, which attempts to re-create the work of https://github.com/foxglove/studio/pull/4662 off of `main`.