### PR TITLE
Add logdepthbuf includes, use ShaderMaterial instead of RawShaderMaterial

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/three-text",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Render text in 3D using Signed Distance Fields",
   "license": "MIT",
   "repository": {

--- a/src/LabelPool.stories.tsx
+++ b/src/LabelPool.stories.tsx
@@ -54,7 +54,7 @@ class StoryScene {
 
   bgCube?: THREE.Mesh;
 
-  constructor() {
+  constructor(private options: { logDepthBuffer: boolean }) {
     this.perspectiveCamera.position.set(4, 4, 4);
     this.scene.background = new THREE.Color(0xf0f0f0);
     this.scene.add(new THREE.AxesHelper(5));
@@ -79,7 +79,11 @@ class StoryScene {
   };
 
   setCanvas(canvas: HTMLCanvasElement) {
-    this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    this.renderer = new THREE.WebGLRenderer({
+      canvas,
+      antialias: true,
+      logarithmicDepthBuffer: this.options.logDepthBuffer,
+    });
     this.renderer.setPixelRatio(window.devicePixelRatio);
 
     this.perspectiveCamera.aspect = canvas.clientWidth / canvas.clientHeight;
@@ -118,6 +122,7 @@ function BasicTemplate({
   positionX,
   positionY,
   positionZ,
+  logDepthBuffer = false,
 }: {
   text: string;
   lineHeight: number;
@@ -134,10 +139,11 @@ function BasicTemplate({
   positionX: number;
   positionY: number;
   positionZ: number;
+  logDepthBuffer: boolean;
 }): JSX.Element {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
-  const [storyScene] = useState(() => new StoryScene());
+  const [storyScene] = useState(() => new StoryScene({ logDepthBuffer }));
   const [label, setLabel] = useState<Label>();
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -236,5 +242,10 @@ export const CustomColors: StoryObj<typeof meta> = {
     backgroundColor: "#1295d1",
     bgOpacity: 0.8,
     fgOpacity: 0.3,
+  },
+};
+export const LogarithmicDepth: StoryObj<typeof meta> = {
+  args: {
+    logDepthBuffer: true,
   },
 };


### PR DESCRIPTION
### Public-Facing Changes

Fixed text rendering when WebGLRenderer.logarithmicDepthBuffer is enabled.

### Description

Supersedes / closes #259 

Subclassing from ShaderMaterial instead of RawShaderMaterial makes three.js automatically prepend the correct `#define` for log depth to work.

I could not recall a specific reason why we were using RawShaderMaterial instead of ShaderMaterial. I suspect it might have been because `position` used to be a `vec2` instead of the standard `vec3` (this changed in #173).