### PR TITLE
Add provenance attestation to npm package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
 
@@ -28,7 +33,7 @@ jobs:
 
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: yarn npm publish --access public
+        run: yarn npm publish --provenance --access public
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/three-text",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Render text in 3D using Signed Distance Fields",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
### Changelog
None

### Description

This is a first attempt to set up provenance attestations for published packages:

- https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
- https://github.blog/2023-04-19-introducing-npm-package-provenance/

The package should appear like this in npm:

<img src="https://github.blog/wp-content/uploads/2023/04/npm-package-provenance-3.png?w=488&resize=488%2C394" width="250">
