### PR TITLE
Use npm instead of yarn to publish with provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       - run: yarn pack
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        # `yarn npm publish` does not currently support --provenance: https://github.com/yarnpkg/berry/issues/5430
         run: npm publish package.tgz --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,12 @@ jobs:
       - run: yarn run lint:ci
       - run: yarn run test
 
+      - run: yarn pack
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: yarn npm publish --provenance --access public
+        run: npm publish package.tgz --provenance --access public
         env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
   chromatic:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ node_modules/
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+package.tgz


### PR DESCRIPTION
### Changelog
None

### Description

Follow-up from #278. It appears `yarn npm publish` does not support `--provenance` (https://github.com/yarnpkg/berry/issues/5430). Per https://github.com/yarnpkg/berry/issues/5430#issuecomment-1768499845 this can be worked around by using `yarn pack` with `npm publish`.