### PR TITLE
Upgrade three.js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/three-text",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Render text in 3D using Signed Distance Fields",
   "license": "MIT",
   "repository": {
@@ -32,7 +32,7 @@
     "@mapbox/tiny-sdf": "2.0.6"
   },
   "peerDependencies": {
-    "three": ">=0.140.2"
+    "three": ">=0.157.0"
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "2.0.0",
@@ -43,7 +43,7 @@
     "@types/jest": "29.5.14",
     "@types/node": "22.7.5",
     "@types/react": "18.3.3",
-    "@types/three": "0.165.0",
+    "@types/three": "0.174.0",
     "chromatic": "11.3.2",
     "eslint": "9.14.0",
     "eslint-plugin-storybook": "0.11.0",
@@ -56,7 +56,7 @@
     "react-dom": "18.3.1",
     "rimraf": "6.0.1",
     "storybook": "7.6.16",
-    "three": "0.165.0",
+    "three": "0.174.0",
     "ts-jest": "29.2.5",
     "typescript": "5.6.3",
     "typescript-eslint": "8.13.0"

--- a/src/LabelPool.ts
+++ b/src/LabelPool.ts
@@ -116,7 +116,7 @@ void main() {
 
   bool insideChar = vInsideChar.x >= 0.0 && vInsideChar.x <= 1.0 && vInsideChar.y >= 0.0 && vInsideChar.y <= 1.0;
   outColor = insideChar ? outColor : uBackgroundColor;
-  outColor = LinearTosRGB(outColor); // assumes output encoding is srgb
+  outColor = sRGBTransferOETF(outColor); // assumes output encoding is srgb
 
   #include <logdepthbuf_fragment>
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1890,7 +1890,7 @@ __metadata:
     "@types/jest": "npm:29.5.14"
     "@types/node": "npm:22.7.5"
     "@types/react": "npm:18.3.3"
-    "@types/three": "npm:0.165.0"
+    "@types/three": "npm:0.174.0"
     chromatic: "npm:11.3.2"
     eslint: "npm:9.14.0"
     eslint-plugin-storybook: "npm:0.11.0"
@@ -1903,12 +1903,12 @@ __metadata:
     react-dom: "npm:18.3.1"
     rimraf: "npm:6.0.1"
     storybook: "npm:7.6.16"
-    three: "npm:0.165.0"
+    three: "npm:0.174.0"
     ts-jest: "npm:29.2.5"
     typescript: "npm:5.6.3"
     typescript-eslint: "npm:8.13.0"
   peerDependencies:
-    three: ">=0.140.2"
+    three: ">=0.157.0"
   languageName: unknown
   linkType: soft
 
@@ -3939,10 +3939,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tweenjs/tween.js@npm:~23.1.1":
-  version: 23.1.2
-  resolution: "@tweenjs/tween.js@npm:23.1.2"
-  checksum: 8fa754b5fd548750e8cc26a4094b46578ee376bf15e1942e042fb532f469dca31f41c48b4d582f1fabceafa705be31b83d11dd79401a518fbabd97d1472c87df
+"@tweenjs/tween.js@npm:~23.1.3":
+  version: 23.1.3
+  resolution: "@tweenjs/tween.js@npm:23.1.3"
+  checksum: 811b30f5f0e7409fb41833401c501c2d6f600eb5f43039dd9067a7f70aff6dad5f5ce1233848e13f0b33a269a160d9c133f344d986cbff4f1f6b72ddecd06c89
   languageName: node
   linkType: hard
 
@@ -4369,16 +4369,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/three@npm:0.165.0":
-  version: 0.165.0
-  resolution: "@types/three@npm:0.165.0"
+"@types/three@npm:0.174.0":
+  version: 0.174.0
+  resolution: "@types/three@npm:0.174.0"
   dependencies:
-    "@tweenjs/tween.js": "npm:~23.1.1"
+    "@tweenjs/tween.js": "npm:~23.1.3"
     "@types/stats.js": "npm:*"
     "@types/webxr": "npm:*"
+    "@webgpu/types": "npm:*"
     fflate: "npm:~0.8.2"
     meshoptimizer: "npm:~0.18.1"
-  checksum: a7d922c5d50610047b55443e3e7ac91cebb424a4fb09294f34ee1d9fc24c3cb5261739ae41ef7fa5ce88584045c7ee885ca28a5b741bd45f93d9da8278ed2473
+  checksum: 338e9d8d01d373014ee3c3b686a0d633c1a29603fe199c7c5340fc1a35c17e6eea0d0a7bba5ff9a33b8e462e5b471c0829c2aaa34ab2300e8d6e7e3f885e45b5
   languageName: node
   linkType: hard
 
@@ -4690,6 +4691,13 @@ __metadata:
     "@webassemblyjs/ast": "npm:1.11.6"
     "@xtuc/long": "npm:4.2.2"
   checksum: 916b90fa3a8aadd95ca41c21d4316d0a7582cf6d0dcf6d9db86ab0de823914df513919fba60ac1edd227ff00e93a66b927b15cbddd36b69d8a34c8815752633c
+  languageName: node
+  linkType: hard
+
+"@webgpu/types@npm:*":
+  version: 0.1.59
+  resolution: "@webgpu/types@npm:0.1.59"
+  checksum: 8f02d06c743de8dde333d3bd99594dab3de65536ea17828f927583b7aae85b6fde8f9af353c905c1654100304816d41fc3f02cfaab53a1008671faedffb655f3
   languageName: node
   linkType: hard
 
@@ -12831,10 +12839,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"three@npm:0.165.0":
-  version: 0.165.0
-  resolution: "three@npm:0.165.0"
-  checksum: 235e52d4634c4fc400de7850af466fdcfaf70c621463a8d886b332faccfbc1c4f697cd67bf848da21e1b6e2fb3e7a153aafc217238ee50923b1a5ce7d47d3973
+"three@npm:0.174.0":
+  version: 0.174.0
+  resolution: "three@npm:0.174.0"
+  checksum: 704c3aaa72a7e97ad4f829e81870c8add856ab5a8fb4fc34e391033c527df5cb87a283edb88e69d2d6974bee8afe732c616e879081c8ea232103aa806b97793b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changelog
Now compatible with three.js r157+

### Docs

None

### Description

Closes #391 

The `LinearTosRGB` function was renamed in r157 https://github.com/mrdoob/three.js/pull/26644 and the old function was removed in r167 https://github.com/mrdoob/three.js/pull/28901