### PR TITLE
FG-13915: Fix scale-invariant label picking

### DIFF
--- a/src/Label.ts
+++ b/src/Label.ts
@@ -71,10 +71,8 @@ export class Label extends THREE.Object3D {
 
     this.mesh.onBeforeRender = (renderer, _scene, _camera, _geometry, _material, _group) => {
       renderer.getSize(tempVec2);
-      this.material.uniforms.uCanvasSize!.value[0] = tempVec2.x;
-      this.material.uniforms.uCanvasSize!.value[1] = tempVec2.y;
-      this.pickingMaterial.uniforms.uCanvasSize!.value[0] = tempVec2.x;
-      this.pickingMaterial.uniforms.uCanvasSize!.value[1] = tempVec2.y;
+      (this.material.uniforms.resolution!.value as THREE.Vector2).copy(tempVec2);
+      (this.pickingMaterial.uniforms.resolution!.value as THREE.Vector2).copy(tempVec2);
     };
 
     this.add(this.mesh);

--- a/src/LabelMaterial.ts
+++ b/src/LabelMaterial.ts
@@ -22,7 +22,7 @@ uniform float uScale;
 uniform vec2 uLabelSize;
 uniform vec2 uTextureSize;
 uniform vec2 uAnchorPoint;
-uniform vec2 uCanvasSize;
+uniform vec2 resolution;
 
 in vec2 instanceBoxPosition, instanceCharPosition;
 in vec2 instanceUv;
@@ -52,10 +52,12 @@ void main() {
       scale.x = length(vec3(modelMatrix[0].xyz));
       scale.y = length(vec3(modelMatrix[1].xyz));
 
+      // Add offset in view space before projection so that setViewOffset
+      // (used by the Picker) works correctly. Multiplying by distance
+      // compensates for the perspective divide, keeping constant pixel size.
+      float dist = -mvPosition.z;
+      mvPosition.xy += vertexPos * 2. * dist / resolution * scale;
       gl_Position = projectionMatrix * mvPosition;
-
-      // Add position after projection to maintain constant pixel size
-      gl_Position.xy += vertexPos * 2. / uCanvasSize * scale * gl_Position.w;
     }
   } else {
     gl_Position = projectionMatrix * modelViewMatrix * vec4(vertexPos, 0.0, 1.0);
@@ -125,7 +127,7 @@ void main() {
         uBillboard: { value: false },
         uSizeAttenuation: { value: true },
         uLabelSize: { value: [0, 0] },
-        uCanvasSize: { value: [0, 0] },
+        resolution: { value: new THREE.Vector2(1, 1) },
         uScale: { value: 0 },
         uTextureSize: {
           value: [params.atlasTexture?.image.width ?? 0, params.atlasTexture?.image.height ?? 0],


### PR DESCRIPTION
### Changelog

Fixed scale-invariant billboard text labels not being pickable in the 3D panel.

### Docs

None

### Description

Fixes: [FG-13915](https://linear.app/foxglove/issue/FG-13915)

**Problem:** Billboard text labels with `scale_invariant=true` (`sizeAttenuation=false` in three-text) were not clickable in the 3D panel's select mode. The Picker renders objects into a small offscreen target using `camera.setViewOffset()` to zoom into the area around the cursor, then reads back pixel colors to determine what was clicked. The `sizeAttenuation=false` vertex shader path added offsets in clip space (after projection), which produces incorrect positions when `setViewOffset` modifies the projection matrix.

**Solution:** Move the `sizeAttenuation=false` offset calculation from clip space to view space (before projection). Multiply by camera distance (`-mvPosition.z`) to compensate for perspective divide, maintaining constant pixel size. This approach is compatible with `setViewOffset` because the projection matrix is applied after the offset.

Before (clip-space offset, broken with setViewOffset):
https://github.com/foxglove/three-text/blob/59edb1756e45486c01e684f28c567fa0e8aecafc/src/LabelMaterial.ts#L55-L57

After (view-space offset, works with setViewOffset):
https://github.com/foxglove/three-text/blob/b7705f3dae05358b5ce2750c91d76fc2fe40f1c9/src/LabelMaterial.ts#L55-L60

Also renamed `uCanvasSize` uniform to `resolution` (Three.js convention) and changed its type from `[0, 0]` array to `THREE.Vector2(1, 1)` to use `.copy()` in `onBeforeRender`.

**Testing:** Verified with a [test data server](https://github.com/foxglove/niels-shared/tree/main/claude/example-projects/fg-13915) that publishes a 3D scene with both `scale_invariant=true` and `scale_invariant=false` labels. Confirmed:
- Before fix: only green (scale_invariant=false) labels pickable
- After fix: both green and yellow (scale_invariant=true) labels pickable
- Reverted to main and re-verified the bug returns

**Note:** This PR should be merged after #448 (WebGPU support) lands, then the app's Picker.ts resolution override (lines 297-302) should also be removed in a follow-up.