### PR TITLE
Fix picking of labels by updating based on viewport instead of render…

### DIFF
--- a/src/Label.ts
+++ b/src/Label.ts
@@ -91,6 +91,9 @@ export abstract class Label extends THREE.Object3D {
 
     this.mesh = new InstancedMeshWithBasicBoundingSphere(this.geometry, this.material, 1);
     this.mesh.userData.pickingMaterial = this.pickingMaterial;
+    this.mesh.onBeforeRender = (renderer, scene, camera, geometry, _material, group) => {
+      this.pickingMaterial.onBeforeRender(renderer, scene, camera, geometry, this.mesh, group);
+    };
 
     this.add(this.mesh);
 

--- a/src/LabelPool.stories.tsx
+++ b/src/LabelPool.stories.tsx
@@ -1,5 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-webpack5";
-import { useEffect, useRef, useState, type ReactElement } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent,
+  type ReactElement,
+} from "react";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import { WebGPURenderer } from "three/webgpu";
@@ -7,6 +14,12 @@ import { WebGPURenderer } from "three/webgpu";
 import type { Label, LabelPoolBase } from "./common.ts";
 import { LabelPool as LabelPoolWebGL } from "./webgl/index.ts";
 import { LabelPool as LabelPoolWebGPU } from "./webgpu/index.ts";
+
+const CANVAS_SIZE = 400;
+const PICK_PIXEL_WIDTH = 31;
+const PICK_PIXEL_CENTER = (PICK_PIXEL_WIDTH / 2) | 0;
+const NULL_SCENE = null as unknown as THREE.Scene;
+const NULL_GROUP = null as unknown as THREE.Group;
 
 const meta: Meta<typeof BasicTemplate> = {
   title: "LabelPool",
@@ -16,7 +29,7 @@ const meta: Meta<typeof BasicTemplate> = {
     renderer: { control: false },
     cameraMode: { control: "inline-radio", options: ["perspective", "orthographic"] },
     lineHeight: { control: { type: "range", min: 0.5, max: 20, step: 0.01 } },
-    scaleFactor: { control: { type: "range", min: 0, max: 2, step: 0.01 } },
+    scaleFactor: { control: { type: "range", min: 0, max: 40, step: 0.01 } },
     bgOpacity: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
     fgOpacity: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
     anchorPointX: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
@@ -45,56 +58,266 @@ const meta: Meta<typeof BasicTemplate> = {
 };
 export default meta;
 
+type StoryRenderer = WebGPURenderer | THREE.WebGLRenderer;
+
+type CssRect = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+type PickDebugResult = {
+  label?: string;
+  status:
+    | "picked"
+    | "none"
+    | "not-ready"
+    | "outside-canvas"
+    | "unsupported-renderer"
+    | "no-pickable-objects";
+  renderer?: "webgl" | "webgpu";
+  canvasX: number;
+  canvasY: number;
+  drawingBufferWidth?: number;
+  drawingBufferHeight?: number;
+  pixelRatio?: number;
+  viewOffset?: CssRect;
+  pickViewportRect?: CssRect;
+  readX?: number;
+  readY?: number;
+  pixel?: [number, number, number, number];
+  objectId?: number;
+  objectIds: { id: number; label: string }[];
+  renderItemCount?: number;
+  renderedPickingItemCount?: number;
+};
+
+type PickRequest = {
+  canvasX: number;
+  canvasY: number;
+  queryId: number;
+};
+
+type PickMaterial = THREE.Material & {
+  uniforms?: Record<string, { value: unknown } | undefined>;
+};
+
+type StoryRenderItem = {
+  object: THREE.Object3D;
+  geometry: THREE.BufferGeometry | null;
+  material: THREE.Material;
+  group: THREE.Group | null;
+};
+
+type MaterialState = {
+  material: THREE.Material;
+  blending: THREE.Blending;
+};
+
 type StorySceneOptions = {
   renderer: "webgpu" | "webgpu-force-webgl" | "webgl";
   logDepthBuffer: boolean;
 };
+
+function isWebGLRenderer(renderer: StoryRenderer): renderer is THREE.WebGLRenderer {
+  return renderer instanceof THREE.WebGLRenderer;
+}
+
+function getCanvasPointerPosition(
+  canvas: HTMLCanvasElement,
+  event: globalThis.MouseEvent,
+): PickRequest {
+  const canvasRect = canvas.getBoundingClientRect();
+  const canvasX =
+    canvasRect.width > 0
+      ? ((event.clientX - canvasRect.left) / canvasRect.width) * canvas.clientWidth
+      : 0;
+  const canvasY =
+    canvasRect.height > 0
+      ? ((event.clientY - canvasRect.top) / canvasRect.height) * canvas.clientHeight
+      : 0;
+
+  return {
+    canvasX,
+    canvasY,
+    queryId: 0,
+  };
+}
+
+function containsPoint(rect: CssRect, x: number, y: number): boolean {
+  return (
+    x >= rect.left && x < rect.left + rect.width && y >= rect.top && y < rect.top + rect.height
+  );
+}
+
+function formatRect(rect: CssRect): string {
+  return `${rect.left.toFixed(1)},${rect.top.toFixed(1)} ${rect.width.toFixed(1)}x${rect.height.toFixed(1)}`;
+}
+
+function formatPickDebugTooltip(queryId: number, pickResult: PickDebugResult): string {
+  const lines = [
+    `q${queryId} ${pickResult.status}: ${pickResult.label ?? "None"}`,
+    `xy ${pickResult.canvasX.toFixed(1)},${pickResult.canvasY.toFixed(1)}`,
+  ];
+
+  if (pickResult.renderer != undefined) {
+    lines.push(`renderer ${pickResult.renderer}`);
+  }
+  if (pickResult.drawingBufferWidth != undefined && pickResult.drawingBufferHeight != undefined) {
+    lines.push(`buffer ${pickResult.drawingBufferWidth}x${pickResult.drawingBufferHeight}`);
+  }
+  if (pickResult.pixelRatio != undefined) {
+    lines.push(`pixelRatio ${pickResult.pixelRatio.toFixed(2)}`);
+  }
+  if (pickResult.viewOffset != undefined) {
+    lines.push(`viewOffset ${formatRect(pickResult.viewOffset)}`);
+  }
+  if (pickResult.pickViewportRect != undefined) {
+    lines.push(`pick viewport css ${formatRect(pickResult.pickViewportRect)}`);
+  }
+  if (pickResult.readX != undefined && pickResult.readY != undefined) {
+    lines.push(`read ${pickResult.readX},${pickResult.readY}`);
+  }
+  if (pickResult.pixel != undefined) {
+    lines.push(
+      `pixel ${pickResult.pixel.join(",")} objectId ${pickResult.objectId ?? "n/a"} ${pickResult.label ?? "None"}`,
+    );
+  }
+  if (pickResult.renderItemCount != undefined) {
+    lines.push(
+      `render list ${pickResult.renderItemCount} items, rendered ${pickResult.renderedPickingItemCount ?? 0} picking items`,
+    );
+  }
+
+  const objectIds =
+    pickResult.objectIds.length > 0
+      ? pickResult.objectIds.map(({ id, label }) => `${id}:${label}`).join(", ")
+      : "none";
+  lines.push(`ids ${objectIds}`);
+
+  return lines.join("\n");
+}
+
+function pickLabelForObject(object: THREE.Object3D): string {
+  const parentName = object.parent?.name;
+  if (parentName != undefined && parentName.length > 0) {
+    return parentName;
+  }
+
+  if (object.name.length > 0) {
+    return object.name;
+  }
+
+  return "Label";
+}
+
+function getPickingMaterial(object: THREE.Object3D): PickMaterial | undefined {
+  const pickingMaterial = object.userData.pickingMaterial as PickMaterial | undefined;
+  if (pickingMaterial?.isMaterial === true && pickingMaterial.uniforms?.objectId != undefined) {
+    return pickingMaterial;
+  }
+
+  return undefined;
+}
+
+function setObjectId(material: PickMaterial, objectId: number): void {
+  const uniform = material.uniforms?.objectId;
+  const value = uniform?.value;
+  if (uniform == undefined || value == undefined) {
+    return;
+  }
+
+  const unsignedObjectId = objectId >>> 0;
+  const r = ((unsignedObjectId >> 24) & 0xff) / 255;
+  const g = ((unsignedObjectId >> 16) & 0xff) / 255;
+  const b = ((unsignedObjectId >> 8) & 0xff) / 255;
+  const a = (unsignedObjectId & 0xff) / 255;
+
+  if (Array.isArray(value)) {
+    value[0] = r;
+    value[1] = g;
+    value[2] = b;
+    value[3] = a;
+  } else if (value instanceof THREE.Vector4) {
+    value.set(r, g, b, a);
+  }
+}
+
+function setPickingResolution(material: PickMaterial, width: number, height: number): void {
+  const value = material.uniforms?.resolution?.value;
+  if (Array.isArray(value)) {
+    value[0] = width;
+    value[1] = height;
+  } else if (value instanceof THREE.Vector2) {
+    value.set(width, height);
+  }
+}
+
+function objectIdFromPixel(pixel: Uint8Array): number {
+  return (pixel[0]! << 24) | (pixel[1]! << 16) | (pixel[2]! << 8) | pixel[3]!;
+}
+
 class StoryScene {
   labelPool: LabelPoolBase;
 
   perspectiveCamera = new THREE.PerspectiveCamera(45, 1, 0.1, 2000);
   orthographicCamera = new THREE.OrthographicCamera(-5, 5, 5, -5, 0.1, 1000);
   scene = new THREE.Scene();
-  renderer?: WebGPURenderer | THREE.WebGLRenderer;
+  pickingScene = new THREE.Scene();
+  renderer?: StoryRenderer;
   initialized = false;
   controls?: OrbitControls;
+  canvas?: HTMLCanvasElement;
 
   perspective = true;
 
   bgCube?: THREE.Mesh;
 
   private options: StorySceneOptions;
+  private pickingRenderTarget?: THREE.WebGLRenderTarget;
+  private pickQueue = Promise.resolve();
 
   constructor(options: StorySceneOptions) {
     this.options = options;
     this.labelPool = options.renderer === "webgl" ? new LabelPoolWebGL() : new LabelPoolWebGPU();
     this.perspectiveCamera.position.set(4, 4, 4);
     this.scene.background = new THREE.Color(0xf0f0f0);
-    this.scene.add(new THREE.AxesHelper(5));
+    const axes = new THREE.AxesHelper(5);
+    axes.userData.picking = false;
+    this.scene.add(axes);
     // show transparency in snapshot tests
     const cubeGeometry = new THREE.BoxGeometry(0.2, 0.2, 2);
     const cubeMaterial = new THREE.MeshNormalMaterial();
     this.bgCube = new THREE.Mesh(cubeGeometry, cubeMaterial);
+    this.bgCube.userData.picking = false;
     this.bgCube.position.set(0, 0, -0.8);
     this.scene.add(this.bgCube);
   }
 
   dispose() {
     this.controls?.dispose();
+    this.pickingRenderTarget?.dispose();
     this.renderer?.dispose();
   }
 
+  get activeCamera(): THREE.PerspectiveCamera | THREE.OrthographicCamera {
+    return this.perspective ? this.perspectiveCamera : this.orthographicCamera;
+  }
+
   render = () => {
-    if (!this.initialized) {
+    if (!this.initialized || !this.renderer) {
       return;
     }
-    this.renderer?.render(
-      this.scene,
-      this.perspective ? this.perspectiveCamera : this.orthographicCamera,
-    );
+
+    this.renderer.setRenderTarget(null);
+    this.applyFullCanvasViewport();
+    this.renderer.render(this.scene, this.activeCamera);
   };
 
   setCanvas(canvas: HTMLCanvasElement) {
+    this.canvas = canvas;
+
     if (this.options.renderer === "webgpu" || this.options.renderer === "webgpu-force-webgl") {
       this.renderer = new WebGPURenderer({
         canvas,
@@ -139,7 +362,251 @@ class StoryScene {
       this.render();
     });
   }
+
+  async pickAt(canvasX: number, canvasY: number): Promise<PickDebugResult> {
+    const pickResult = this.pickQueue.then(
+      async () => await this.pickAtNow(canvasX, canvasY),
+      async () => await this.pickAtNow(canvasX, canvasY),
+    );
+    this.pickQueue = pickResult.then(
+      async () => undefined,
+      async () => undefined,
+    );
+
+    return await pickResult;
+  }
+
+  private async pickAtNow(canvasX: number, canvasY: number): Promise<PickDebugResult> {
+    if (!this.initialized || !this.renderer || !this.canvas) {
+      return {
+        status: "not-ready",
+        canvasX,
+        canvasY,
+        objectIds: [],
+      };
+    }
+
+    const canvasRect = this.getFullCanvasRect();
+    if (!containsPoint(canvasRect, canvasX, canvasY)) {
+      return {
+        status: "outside-canvas",
+        canvasX,
+        canvasY,
+        objectIds: [],
+      };
+    }
+
+    const renderer = this.renderer;
+    if (!isWebGLRenderer(renderer)) {
+      return {
+        status: "unsupported-renderer",
+        renderer: "webgpu",
+        canvasX,
+        canvasY,
+        objectIds: [],
+      };
+    }
+
+    this.render();
+
+    const renderList = renderer.renderLists.get(this.scene, 0);
+
+    const renderItems = [
+      ...(renderList.opaque as StoryRenderItem[]),
+      ...(renderList.transmissive as StoryRenderItem[]),
+      ...(renderList.transparent as StoryRenderItem[]),
+    ];
+    const objectIds: { id: number; label: string }[] = [];
+    const objectLabels = new Map<number, string>();
+    const materialStates: MaterialState[] = [];
+    const pickingItems = renderItems.flatMap((renderItem) => {
+      if (renderItem.object.userData.picking === false || renderItem.geometry == undefined) {
+        return [];
+      }
+
+      const pickingMaterial = getPickingMaterial(renderItem.object);
+      if (pickingMaterial == undefined) {
+        return [];
+      }
+      if (!pickingMaterial.visible) {
+        return [];
+      }
+
+      const label = pickLabelForObject(renderItem.object);
+      objectLabels.set(renderItem.object.id, label);
+      objectIds.push({ id: renderItem.object.id, label });
+
+      return [{ ...renderItem, material: pickingMaterial }];
+    });
+
+    if (pickingItems.length === 0) {
+      return {
+        status: "no-pickable-objects",
+        renderer: "webgl",
+        canvasX,
+        canvasY,
+        drawingBufferWidth: renderer.domElement.width,
+        drawingBufferHeight: renderer.domElement.height,
+        pixelRatio: renderer.getPixelRatio(),
+        objectIds,
+        renderItemCount: renderItems.length,
+        renderedPickingItemCount: 0,
+      };
+    }
+
+    const camera = this.activeCamera;
+    const pixelRatio = renderer.getPixelRatio();
+    const drawingBufferWidth = renderer.domElement.width;
+    const drawingBufferHeight = renderer.domElement.height;
+    const viewOffsetX = Math.max(0, canvasX * pixelRatio - PICK_PIXEL_CENTER);
+    const viewOffsetY = Math.max(0, canvasY * pixelRatio - PICK_PIXEL_CENTER);
+    const viewOffset = {
+      left: viewOffsetX,
+      top: viewOffsetY,
+      width: PICK_PIXEL_WIDTH,
+      height: PICK_PIXEL_WIDTH,
+    };
+    const pickViewportRect = {
+      left: viewOffsetX / pixelRatio,
+      top: viewOffsetY / pixelRatio,
+      width: PICK_PIXEL_WIDTH / pixelRatio,
+      height: PICK_PIXEL_WIDTH / pixelRatio,
+    };
+
+    const renderTarget = this.ensurePickingRenderTarget();
+    const previousRenderTarget = renderer.getRenderTarget();
+    const previousClearColor = new THREE.Color();
+    renderer.getClearColor(previousClearColor);
+    const previousClearAlpha = renderer.getClearAlpha();
+    const previousInfoAutoReset = renderer.info.autoReset;
+
+    try {
+      camera.setViewOffset(
+        drawingBufferWidth,
+        drawingBufferHeight,
+        viewOffsetX,
+        viewOffsetY,
+        PICK_PIXEL_WIDTH,
+        PICK_PIXEL_WIDTH,
+      );
+      camera.updateProjectionMatrix();
+
+      renderTarget.viewport.set(0, 0, PICK_PIXEL_WIDTH, PICK_PIXEL_WIDTH);
+      renderTarget.scissor.set(0, 0, PICK_PIXEL_WIDTH, PICK_PIXEL_WIDTH);
+      renderTarget.scissorTest = false;
+      renderer.setRenderTarget(renderTarget);
+      renderer.setViewport(0, 0, PICK_PIXEL_WIDTH, PICK_PIXEL_WIDTH);
+      renderer.setScissor(0, 0, PICK_PIXEL_WIDTH, PICK_PIXEL_WIDTH);
+      renderer.setScissorTest(false);
+      renderer.setClearColor(0xffffff, 1);
+      renderer.clear(true, true, true);
+
+      renderer.info.autoReset = false;
+      renderer.info.reset();
+
+      let renderedPickingItemCount = 0;
+      this.pickingScene.onAfterRender = () => {
+        for (const renderItem of pickingItems) {
+          setObjectId(renderItem.material, renderItem.object.id);
+          setPickingResolution(renderItem.material, PICK_PIXEL_WIDTH, PICK_PIXEL_WIDTH);
+          materialStates.push({
+            material: renderItem.material,
+            blending: renderItem.material.blending,
+          });
+          renderItem.material.blending = THREE.NoBlending;
+          renderer.renderBufferDirect(
+            camera,
+            NULL_SCENE,
+            renderItem.geometry!,
+            renderItem.material,
+            renderItem.object,
+            renderItem.group ?? NULL_GROUP,
+          );
+          renderedPickingItemCount++;
+        }
+      };
+      renderer.render(this.pickingScene, camera);
+
+      const pixel = new Uint8Array(4);
+      renderer.readRenderTargetPixels(
+        renderTarget,
+        PICK_PIXEL_CENTER,
+        PICK_PIXEL_CENTER,
+        1,
+        1,
+        pixel,
+      );
+      const objectId = objectIdFromPixel(pixel);
+      const label = objectLabels.get(objectId);
+
+      return {
+        status: label != undefined ? "picked" : "none",
+        label,
+        renderer: "webgl",
+        canvasX,
+        canvasY,
+        drawingBufferWidth,
+        drawingBufferHeight,
+        pixelRatio,
+        viewOffset,
+        pickViewportRect,
+        readX: PICK_PIXEL_CENTER,
+        readY: PICK_PIXEL_CENTER,
+        pixel: [pixel[0] ?? 0, pixel[1] ?? 0, pixel[2] ?? 0, pixel[3] ?? 0],
+        objectId,
+        objectIds,
+        renderItemCount: renderItems.length,
+        renderedPickingItemCount,
+      };
+    } finally {
+      this.pickingScene.onAfterRender = () => undefined;
+      camera.clearViewOffset();
+      camera.updateProjectionMatrix();
+      for (const state of materialStates) {
+        state.material.blending = state.blending;
+      }
+      renderer.info.autoReset = previousInfoAutoReset;
+      renderer.setClearColor(previousClearColor, previousClearAlpha);
+      renderer.setRenderTarget(previousRenderTarget);
+      this.applyFullCanvasViewport();
+    }
+  }
+
+  private getFullCanvasRect(): CssRect {
+    if (!this.canvas) {
+      return { left: 0, top: 0, width: CANVAS_SIZE, height: CANVAS_SIZE };
+    }
+
+    return {
+      left: 0,
+      top: 0,
+      width: this.canvas.clientWidth,
+      height: this.canvas.clientHeight,
+    };
+  }
+
+  private applyFullCanvasViewport(): void {
+    if (!this.renderer || !this.canvas) {
+      return;
+    }
+
+    this.renderer.setViewport(0, 0, this.canvas.clientWidth, this.canvas.clientHeight);
+    this.renderer.setScissor(0, 0, this.canvas.clientWidth, this.canvas.clientHeight);
+    this.renderer.setScissorTest(false);
+  }
+
+  private ensurePickingRenderTarget(): THREE.WebGLRenderTarget {
+    this.pickingRenderTarget ??= new THREE.WebGLRenderTarget(PICK_PIXEL_WIDTH, PICK_PIXEL_WIDTH, {
+      depthBuffer: true,
+      magFilter: THREE.NearestFilter,
+      minFilter: THREE.NearestFilter,
+      stencilBuffer: false,
+    });
+
+    return this.pickingRenderTarget;
+  }
 }
+
 function BasicTemplate({
   renderer = "webgl",
   text,
@@ -178,9 +645,12 @@ function BasicTemplate({
   logDepthBuffer: boolean;
 }): ReactElement {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const pickQueryIdRef = useRef(0);
 
   const [storyScene] = useState(() => new StoryScene({ renderer, logDepthBuffer }));
   const [label, setLabel] = useState<Label>();
+  const [pickDebugText, setPickDebugText] = useState("Click the canvas to run a pick query.");
+  const [lastPickViewportRect, setLastPickViewportRect] = useState<CssRect>();
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) {
@@ -188,6 +658,7 @@ function BasicTemplate({
     }
     storyScene.setCanvas(canvas);
     const newLabel = storyScene.labelPool.acquire();
+    newLabel.name = "Label";
     setLabel(newLabel);
 
     storyScene.scene.add(newLabel);
@@ -268,7 +739,87 @@ function BasicTemplate({
     }
   }, [label, positionX, positionY, positionZ, storyScene]);
 
-  return <canvas ref={canvasRef} width={400} height={400} style={{ width: 400, height: 400 }} />;
+  const handleClick = useCallback(
+    (event: PointerEvent<HTMLCanvasElement>) => {
+      const pickRequest = {
+        ...getCanvasPointerPosition(event.currentTarget, event.nativeEvent),
+        queryId: ++pickQueryIdRef.current,
+      };
+
+      setPickDebugText(
+        `q${pickRequest.queryId} pending\nxy ${pickRequest.canvasX.toFixed(1)},${pickRequest.canvasY.toFixed(1)}`,
+      );
+
+      void (async () => {
+        try {
+          const pickResult = await storyScene.pickAt(pickRequest.canvasX, pickRequest.canvasY);
+          if (pickQueryIdRef.current !== pickRequest.queryId) {
+            return;
+          }
+
+          setLastPickViewportRect(pickResult.pickViewportRect);
+          setPickDebugText(formatPickDebugTooltip(pickRequest.queryId, pickResult));
+        } catch (error: unknown) {
+          console.error("Failed to pick clicked label", error);
+          if (pickQueryIdRef.current !== pickRequest.queryId) {
+            return;
+          }
+
+          setPickDebugText(
+            `q${pickRequest.queryId} error\nxy ${pickRequest.canvasX.toFixed(1)},${pickRequest.canvasY.toFixed(1)}\n${String(error)}`,
+          );
+        }
+      })();
+    },
+    [storyScene],
+  );
+
+  return (
+    <div style={{ width: CANVAS_SIZE }}>
+      <div style={{ position: "relative", width: CANVAS_SIZE, height: CANVAS_SIZE }}>
+        <canvas
+          ref={canvasRef}
+          width={CANVAS_SIZE}
+          height={CANVAS_SIZE}
+          onClick={handleClick}
+          style={{ width: CANVAS_SIZE, height: CANVAS_SIZE }}
+        />
+        {lastPickViewportRect != undefined && (
+          <div
+            aria-hidden
+            style={{
+              position: "absolute",
+              left: lastPickViewportRect.left,
+              top: lastPickViewportRect.top,
+              width: lastPickViewportRect.width,
+              height: lastPickViewportRect.height,
+              border: "1px solid rgba(255, 48, 48, 0.95)",
+              boxShadow: "0 0 0 1px rgba(255, 255, 255, 0.8)",
+              boxSizing: "border-box",
+              pointerEvents: "none",
+            }}
+          />
+        )}
+      </div>
+      <textarea
+        readOnly
+        aria-label="Pick debug output"
+        value={pickDebugText}
+        style={{
+          display: "block",
+          width: "100%",
+          height: 180,
+          marginTop: 8,
+          boxSizing: "border-box",
+          resize: "vertical",
+          fontFamily: "monospace",
+          fontSize: 12,
+          lineHeight: "16px",
+          whiteSpace: "pre",
+        }}
+      />
+    </div>
+  );
 }
 
 export const Basic: StoryObj<typeof meta> = {};

--- a/src/webgl/LabelMaterial.ts
+++ b/src/webgl/LabelMaterial.ts
@@ -2,7 +2,7 @@ import * as THREE from "three";
 
 import type { ILabelMaterial } from "../ILabelMaterial.ts";
 
-const tempVec2 = new THREE.Vector2();
+const tempVec4 = new THREE.Vector4();
 
 export class LabelMaterial extends THREE.ShaderMaterial implements ILabelMaterial {
   picking: boolean;
@@ -23,7 +23,8 @@ uniform float uScale;
 uniform vec2 uLabelSize;
 uniform vec2 uTextureSize;
 uniform vec2 uAnchorPoint;
-uniform vec2 uCanvasSize;
+uniform float uPixelRatio;
+uniform vec2 resolution;
 
 in vec2 instanceBoxPosition, instanceCharPosition;
 in vec2 instanceUv;
@@ -51,10 +52,11 @@ void main() {
       scale.x = length(vec3(modelMatrix[0].xyz));
       scale.y = length(vec3(modelMatrix[1].xyz));
 
+      vec2 ndcOffset = vertexPos * scale * uPixelRatio * 2.0 / resolution;
+      vec2 projectionScale = vec2(projectionMatrix[0][0], projectionMatrix[1][1]);
+      float depthScale = isPerspectiveMatrix(projectionMatrix) ? -mvPosition.z : 1.0;
+      mvPosition.xy += ndcOffset * depthScale / projectionScale;
       gl_Position = projectionMatrix * mvPosition;
-
-      // Add position after projection to maintain constant pixel size
-      gl_Position.xy += vertexPos * 2. / uCanvasSize * scale * gl_Position.w;
     }
   } else {
     gl_Position = projectionMatrix * modelViewMatrix * vec4(vertexPos, 0.0, 1.0);
@@ -123,7 +125,8 @@ void main() {
         uBillboard: { value: false },
         uSizeAttenuation: { value: true },
         uLabelSize: { value: [0, 0] },
-        uCanvasSize: { value: [0, 0] },
+        uPixelRatio: { value: 1 },
+        resolution: { value: new THREE.Vector2(0, 0) },
         uScale: { value: 0 },
         uTextureSize: {
           value: [params.atlasTexture?.image.width ?? 0, params.atlasTexture?.image.height ?? 0],
@@ -139,9 +142,11 @@ void main() {
     });
 
     this.onBeforeRender = (renderer, _scene, _camera, _geometry, _material, _group) => {
-      renderer.getSize(tempVec2);
-      this.uniforms.uCanvasSize!.value[0] = tempVec2.x;
-      this.uniforms.uCanvasSize!.value[1] = tempVec2.y;
+      renderer.getCurrentViewport(tempVec4);
+      const pixelRatio = renderer.getPixelRatio();
+      this.uniforms.uPixelRatio!.value = pixelRatio;
+      const resolution = this.uniforms.resolution!.value as THREE.Vector2;
+      resolution.set(tempVec4.z, tempVec4.w);
     };
 
     this.picking = params.picking ?? false;

--- a/src/webgpu/LabelNodeMaterial.ts
+++ b/src/webgpu/LabelNodeMaterial.ts
@@ -22,7 +22,7 @@ import {
   mix,
   select,
   vertexStage,
-  screenSize,
+  viewportSize,
   screenDPR,
   viewZToLogarithmicDepth,
   viewZToPerspectiveDepth,
@@ -100,12 +100,16 @@ export class LabelNodeMaterial extends NodeMaterial implements ILabelMaterial {
           scale.x.assign(length(vec3(modelWorldMatrix[0].xyz)));
           scale.y.assign(length(vec3(modelWorldMatrix[1].xyz)));
 
-          result.assign(cameraProjectionMatrix.mul(mvPosition));
-
-          // Add position after projection to maintain constant pixel size
-          result.xy.addAssign(
-            vertexPos.mul(2).div(screenSize).mul(screenDPR).mul(scale).mul(result.w),
+          const ndcOffset = vertexPos.mul(2).div(viewportSize).mul(screenDPR).mul(scale);
+          const projectionScale = vec2(cameraProjectionMatrix[0][0], cameraProjectionMatrix[1][1]);
+          const depthScale = select(
+            cameraProjectionMatrix[2][3].equal(-1),
+            mvPosition.z.negate(),
+            1.0,
           );
+
+          mvPosition.xy.addAssign(ndcOffset.mul(depthScale).div(projectionScale));
+          result.assign(cameraProjectionMatrix.mul(mvPosition));
         });
 
         vViewZ.assign(mvPosition.z);


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

Labels with `sizeAttenuation=false` use screen-space offsets so they keep a consistent pixel size. The WebGL shader was deriving those offsets from the renderer size, but that is the full render target size rather than the active viewport. In clipped views, split views, or other custom viewport rendering, the displayed label and its picking material could therefore use the wrong dimensions and drift out of alignment.

This updates the WebGL label material to refresh its uniforms from `renderer.getCurrentViewport()` and the renderer DPR before each render. The visible label mesh also forwards its `onBeforeRender` call to the picking material so picking receives the same current viewport state. The WebGPU material now uses the same pre-projection viewport math with `viewportSize` and `screenDPR`, keeping the two render paths consistent even though WebGPU picking is not implemented yet.

Validation:

- `yarn test`
- `yarn typecheck`
- `yarn lint:ci`

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<img width="489" height="309" alt="Screenshot 2026-06-16 at 1 58 26 PM" src="https://github.com/user-attachments/assets/c1c3b970-c3ba-441d-96ee-1dcc458d5d33" />


Picking bounds for non-size-attenuated billboard labels were computed from the full renderer size and could be offset or scaled incorrectly inside a clipped viewport.

</td><td>

<img width="602" height="312" alt="Screenshot 2026-06-16 at 1 57 38 PM" src="https://github.com/user-attachments/assets/e12d04d2-45bb-4753-b35f-5d7f8ac7434b" />


Label rendering and picking use the active viewport dimensions and device pixel ratio, so screen-space label offsets match the clipped view being rendered.

</td></tr></table>

Fixes: FG-13915
