### PR TITLE
Version 0.7.0, namely for better type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/three-text",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Render text in 3D using Signed Distance Fields",
   "license": "MIT",
   "repository": {
@@ -13,9 +13,16 @@
     "url": "https://foxglove.dev/"
   },
   "type": "module",
+  "types": "./dist/webgl/index.d.ts",
   "exports": {
-    ".": "./dist/webgl/index.js",
-    "./webgpu": "./dist/webgpu/index.js"
+    ".": {
+      "types": "./dist/webgl/index.d.ts",
+      "default": "./dist/webgl/index.js"
+    },
+    "./webgpu": {
+      "types": "./dist/webgpu/index.d.ts",
+      "default": "./dist/webgpu/index.js"
+    }
   },
   "files": [
     "dist",

--- a/src/LabelPool.stories.tsx
+++ b/src/LabelPool.stories.tsx
@@ -657,7 +657,7 @@ function BasicTemplate({
       throw new Error("expected canvas");
     }
     storyScene.setCanvas(canvas);
-    const newLabel = storyScene.labelPool.acquire();
+    const newLabel = storyScene.labelPool.acquire<Label>();
     newLabel.name = "Label";
     setLabel(newLabel);
 

--- a/src/LabelPoolBase.ts
+++ b/src/LabelPoolBase.ts
@@ -3,6 +3,7 @@ import * as THREE from "three";
 import type { FontManagerOptions } from "./FontManager.ts";
 import { FontManager } from "./FontManager.ts";
 import type { Label } from "./Label.ts";
+import type { ThreeTextLabel } from "./ThreeTextLabel.ts";
 
 type EventMap = {
   scaleFactorChange: object;
@@ -72,16 +73,18 @@ export abstract class LabelPoolBase extends THREE.EventDispatcher<EventMap> {
     this.dispatchEvent({ type: "atlasChange" });
   }
 
-  acquire(): Label {
-    return this.availableLabels.pop() ?? this.createLabel();
+  acquire<TObject3D extends object = object>(): ThreeTextLabel<TObject3D> {
+    return (this.availableLabels.pop() ??
+      this.createLabel()) as unknown as ThreeTextLabel<TObject3D>;
   }
 
-  release(label: Label): void {
+  release<TObject3D extends object>(label: ThreeTextLabel<TObject3D>): void {
+    const pooledLabel = label as unknown as Label;
     if (this.disposed) {
-      label.dispose();
+      pooledLabel.dispose();
     } else {
-      label.removeFromParent();
-      this.availableLabels.push(label);
+      pooledLabel.removeFromParent();
+      this.availableLabels.push(pooledLabel);
     }
   }
 

--- a/src/ThreeTextLabel.ts
+++ b/src/ThreeTextLabel.ts
@@ -1,0 +1,22 @@
+export type ThreeTextLabelMaterial = {
+  depthTest: boolean;
+  depthWrite: boolean;
+  transparent: boolean;
+};
+
+export type ThreeTextLabelMesh = {
+  renderOrder: number;
+};
+
+export type ThreeTextLabel<TObject3D extends object = object> = TObject3D & {
+  mesh: ThreeTextLabelMesh;
+  material: ThreeTextLabelMaterial;
+  dispose(): void;
+  setAnchorPoint(x: number, y: number): void;
+  setBackgroundColor(r: number, g: number, b: number, a?: number): void;
+  setBillboard(billboard: boolean): void;
+  setColor(r: number, g: number, b: number, a?: number): void;
+  setLineHeight(lineHeight: number): void;
+  setSizeAttenuation(sizeAttenuation: boolean): void;
+  setText(text: string): void;
+};

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,3 +1,4 @@
 export * from "./FontManager.ts";
 export * from "./Label.ts";
 export * from "./LabelPoolBase.ts";
+export * from "./ThreeTextLabel.ts";


### PR DESCRIPTION
### Changelog

Added typed package exports and a public `ThreeTextLabel` type for TypeScript consumers.

### Docs

None

### Description

`LabelPool.acquire()` previously exposed the concrete internal `Label` class as its public return type. That made downstream consumers depend on more of the package's implementation detail than they actually need, and it can also pull in incompatible local `three` type identities when this package is linked into another TypeScript project.

This change adds a public structural `ThreeTextLabel<TObject3D>` type describing the label API consumers use, exports it from the package root, and updates `LabelPoolBase.acquire()` / `release()` to use that public type. Consumers that need their local `THREE.Object3D` identity can provide it as the generic parameter without importing `Label` internals. The package metadata now declares TypeScript entrypoints for the root and `./webgpu` exports, and the package version is bumped to `0.7.0`.

Validation:

- `yarn typecheck`
- `yarn lint:ci`
- `yarn build`
- Also validated in main foxglove `app` linter and build.
